### PR TITLE
Check length of benchmark names

### DIFF
--- a/src/packages/fluxarchitectures.jl
+++ b/src/packages/fluxarchitectures.jl
@@ -8,12 +8,12 @@ function fluxarchitectures_add_darnn(::FA_GPU, encodersize, decodersize, poollen
     model = DARNN(inputsize, encodersize, decodersize, poollength, 1)
     ip = randn(Float32, inputsize, poollength, 1, datalength)
 
-    fa_group["DARNN_Forward_encoder_$(encodersize)_decoder_$(decodersize)_pool_$(poollength)_input_$(inputsize)_batch_$(datalength)"] = @benchmarkable(
+    fa_group["DARNN_Forward_encoder_input_$(inputsize)_batch_$(datalength)"] = @benchmarkable(
         fw(model, gip), setup = (model = gpu($model); gip = gpu($ip)),
         teardown = (GC.gc(); CUDA.reclaim())
     )
 
-    fa_group["DARNN_Backward_encoder_$(encodersize)_decoder_$(decodersize)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["DARNN_Backward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         bw(model, gip), setup = (model = gpu($model); gip = gpu($ip)),
         teardown = (GC.gc(); CUDA.reclaim())
 )
@@ -25,12 +25,12 @@ function fluxarchitectures_add_dsanet(::FA_GPU, locallength, nkernels, dmodel,
     model = DSANet(inputsize, poollength, locallength, nkernels, dmodel, hid, layers, nhead)
     ip = randn(Float32, inputsize, poollength, 1, datalength)
 
-    fa_group["DSANet_Forward_local_$(locallength)_nkernels_$(nkernels)_dmodel_$(dmodel)_hid_$(hid)_layers_$(layers)_nhead_$(nhead)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["DSANet_Forward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         fw(model, gip), setup = (model = gpu($model); gip = gpu($ip)),
         teardown = (GC.gc(); CUDA.reclaim())
     )
 
-    fa_group["DSANet_Backward_local_$(locallength)_hid_$(hid)_layers_$(layers)_nhead_$(nhead)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["DSANet_Backward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         bw(model, gip), setup = (model = gpu($model); gip = gpu($ip)),
         teardown = (GC.gc(); CUDA.reclaim())
     )
@@ -42,12 +42,12 @@ function fluxarchitectures_add_lstnet(::FA_GPU, convlayersize, recurlayersize,
     model = LSTnet(inputsize, convlayersize, recurlayersize, poollength, skiplength)
     ip = randn(Float32, inputsize, poollength, 1, datalength)
 
-    fa_group["LSTNet_Forward_conv_$(convlayersize)_recur_$(recurlayersize)_skip_$(skiplength)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["LSTNet_Forward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         fw(model, gip), setup = (model = gpu($model); gip = gpu($ip)),
         teardown = (GC.gc(); CUDA.reclaim())
     )
 
-    fa_group["LSTNet_Backward_conv_$(convlayersize)_recur_$(recurlayersize)_skip_$(skiplength)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["LSTNet_Backward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         bw(model, gip), setup = (model = gpu($model); gip = gpu($ip)),
         teardown = (GC.gc(); CUDA.reclaim())
     )
@@ -57,12 +57,12 @@ function fluxarchitectures_add_tpalstm(::FA_GPU, hiddensize, poollength, inputsi
     model = TPALSTM(inputsize, hiddensize, poollength)
     ip = randn(Float32, inputsize, poollength, 1, datalength)
 
-    fa_group["TPALSTM_Forward_hidden_$(hiddensize)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["TPALSTM_Forward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         fw(model, gip), setup = (model = gpu($model); gip = gpu($ip)),
         teardown = (GC.gc(); CUDA.reclaim())
     )
 
-    fa_group["TPALSTM_Backward_hidden_$(hiddensize)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["TPALSTM_Backward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         bw(model, gip), setup = (model = gpu($model); gip = gpu($ip)),
         teardown = (GC.gc(); CUDA.reclaim())
     )
@@ -75,12 +75,12 @@ function fluxarchitectures_add_darnn(::FA_CPU, encodersize, decodersize, poollen
     model = DARNN(inputsize, encodersize, decodersize, poollength, 1)
     ip = randn(Float32, inputsize, poollength, 1, datalength)
 
-    fa_group["DARNN_Forward_encoder_$(encodersize)_decoder_$(decodersize)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["DARNN_Forward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         fw_cpu(model, gip), setup = (model = $model; gip = $ip),
         teardown = ()
     )
 
-    fa_group["DARNN_Backward_encoder_$(encodersize)_decoder_$(decodersize)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["DARNN_Backward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         bw_cpu(model, gip), setup = (model = $model; gip = $ip),
         teardown = ()
 )
@@ -90,12 +90,12 @@ function fluxarchitectures_add_dsanet(::FA_CPU, locallength, nkernels, dmodel, h
     model = DSANet(inputsize, poollength, locallength, nkernels, dmodel, hid, layers, nhead)
     ip = randn(Float32, inputsize, poollength, 1, datalength)
 
-    fa_group["DSANet_Forward_local_$(locallength)_nkernels_$(nkernels)_dmodel_$(dmodel)_hid_$(hid)_layers_$(layers)_nhead_$(nhead)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["DSANet_Forward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         fw_cpu(model, gip), setup = (model = $model; gip = $ip),
         teardown = ()
     )
 
-    fa_group["DSANet_Backward_local_$(locallength)_nkernels_$(nkernels)_dmodel_$(dmodel)_hid_$(hid)_layers_$(layers)_nhead_$(nhead)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["DSANet_Backward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         bw_cpu(model, gip), setup = (model = $model; gip = $ip),
         teardown = ()
     )
@@ -105,12 +105,12 @@ function fluxarchitectures_add_lstnet(::FA_CPU, convlayersize, recurlayersize, p
     model = LSTnet(inputsize, convlayersize, recurlayersize, poollength, skiplength)
     ip = randn(Float32, inputsize, poollength, 1, datalength)
 
-    fa_group["LSTNet_Forward_conv_$(convlayersize)_recur_$(recurlayersize)_skip_$(skiplength)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["LSTNet_Forward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         fw_cpu(model, gip), setup = (model = $model; gip = $ip),
         teardown = ()
     )
 
-    fa_group["LSTNet_Backward_conv_$(convlayersize)_recur_$(recurlayersize)_skip_$(skiplength)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["LSTNet_Backward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         bw_cpu(model, gip), setup = (model = $model; gip = $ip),
         teardown = ()
     )
@@ -120,12 +120,12 @@ function fluxarchitectures_add_tpalstm(::FA_CPU, hiddensize, poollength, inputsi
     model = TPALSTM(inputsize, hiddensize, poollength)
     ip = randn(Float32, inputsize, poollength, 1, datalength)
 
-    fa_group["TPALSTM_Forward_hidden_$(hiddensize)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["TPALSTM_Forward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         fw_cpu(model, gip), setup = (model = $model; gip = $ip),
         teardown = ()
     )
 
-    fa_group["TPALSTM_Backward_hidden_$(hiddensize)_pool_$(poollength)_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
+    fa_group["TPALSTM_Backward_input_$(inputsize)_data_$(datalength)"] = @benchmarkable(
         bw_cpu(model, gip), setup = (model = $model; gip = $ip),
         teardown = ()
     )


### PR DESCRIPTION
The maximum permissible length of benchmark names seems to be 64. I've tried to reduce it for the ones with longer names, but I might have to check whether any others violate this length requirement.